### PR TITLE
[SDPA-4231] Added empty checks for sites & primary sites name and url.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "drupal-module",
     "license": "GPL-2.0-or-later",
     "require": {
-        "dpc-sdp/tide_core": "dev-feature/SDPSUP-1680-tide-workflow-notification-module-check as 1.5.9",
+        "dpc-sdp/tide_core": "^1.5.10",
         "dpc-sdp/tide_event": "^1.3.1",
         "dpc-sdp/tide_landing_page": "^1.2.1",
         "dpc-sdp/tide_media": "^1.5.1",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "drupal-module",
     "license": "GPL-2.0-or-later",
     "require": {
-        "dpc-sdp/tide_core": "^1.5.4",
+        "dpc-sdp/tide_core": "dev-feature/SDPSUP-1680-tide-workflow-notification-module-check as 1.5.9",
         "dpc-sdp/tide_event": "^1.3.1",
         "dpc-sdp/tide_landing_page": "^1.2.1",
         "dpc-sdp/tide_media": "^1.5.1",

--- a/tide_authenticated_content.module
+++ b/tide_authenticated_content.module
@@ -289,10 +289,10 @@ function tide_authenticated_content_entity_view_alter(array &$build, EntityInter
         }
 
         $site_url = $site_helper->getSiteBaseUrl($site);
-        $url = $site_url . '/preview/' . $content_type . '/' . $entity->uuid() . '/' . ($is_latest_revision ? 'latest' : $revision_id);
+        $url = !empty($site_url) ? ($site_url . '/preview/' . $content_type . '/' . $entity->uuid() . '/' . ($is_latest_revision ? 'latest' : $revision_id)) : '';
         $preview_urls[$site_id] = [
-          'name' => $site->getName(),
-          'url' => Url::fromUri($url, $url_options),
+          'name' => !empty($site->getName()) ? $site->getName() : '',
+          'url' => (!empty($url) && !empty($url_options)) ? Url::fromUri($url, $url_options) : '',
         ];
 
         if ($section && $section->id() != $site_id) {
@@ -318,10 +318,10 @@ function tide_authenticated_content_entity_view_alter(array &$build, EntityInter
     }
 
     $primary_site_url = $site_helper->getSiteBaseUrl($primary_site);
-    $url = $primary_site_url . '/preview/' . $content_type . '/' . $entity->uuid() . '/' . ($is_latest_revision ? 'latest' : $revision_id);
+    $url = !empty($primary_site_url) ? ($primary_site_url . '/preview/' . $content_type . '/' . $entity->uuid() . '/' . ($is_latest_revision ? 'latest' : $revision_id)) : '';
     $primary_preview_url = [
-      'name' => $primary_site->getName(),
-      'url' => Url::fromUri($url, $url_options),
+      'name' => !empty($primary_site->getName()) ? $primary_site->getName() : '',
+      'url' => (!empty($url) && !empty($url_options)) ? Url::fromUri($url, $url_options) : '',
     ];
 
     if ($primary_site_section && $primary_site_section->id() != $primary_site->id()) {
@@ -345,9 +345,11 @@ function tide_authenticated_content_entity_view_alter(array &$build, EntityInter
       ],
     ];
     foreach ($preview_urls as $url_data) {
-      $build['preview_links']['#items'][] = [
-        '#markup' => $url_data['name'] . ': ' . Link::fromTextAndUrl($url_data['url']->toString(), $url_data['url'])->toString(),
-      ];
+      if (!empty($url_data['url'])) {
+        $build['preview_links']['#items'][] = [
+          '#markup' => $url_data['name'] . ': ' . Link::fromTextAndUrl($url_data['url']->toString(), $url_data['url'])->toString(),
+        ];
+      }
     }
   }
 }


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SDPA-4231

### Issue
Shrine taxonomy wasn't saved properly and for that reason it when it tried to generate the URL in tide_autehnticated content it was throwing error. Currently, there is no check for empty URLs because the "Domains" field is a mandatory field. But to avoid situations like taxonomy didn't get saved properly and it returns empty URL, the check should be there.

### Changes
1. Added checks for empty URL and site name.