### PR TITLE
SDPA-4186 update jwt module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "dpc-sdp/tide_media": "^1.5.1",
         "dpc-sdp/tide_site": "^1.1.14",
         "drupal/jsonapi_extras": "^3.8",
-        "drupal/jwt": "1.0-alpha6",
+        "drupal/jwt": "1.0-beta1",
         "drupal/permissions_by_term": "v2.12"
     },
     "repositories": {

--- a/tide_authenticated_content.services.yml
+++ b/tide_authenticated_content.services.yml
@@ -1,7 +1,7 @@
 services:
   tide_authenticated_content.authentication.jwt:
     class: Drupal\tide_authenticated_content\Auth\AuthProvider
-    arguments: [ '@entity_type.manager', '@jwt.transcoder', '@event_dispatcher' ]
+    arguments: [ '@jwt.transcoder', '@event_dispatcher' ]
     tags:
       - { name: authentication_provider, provider_id: 'tide_protect_auth', global: TRUE, priority: 1 }
   tide_authenticated_content.authenticated_content_route_subscriber:


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SDPA-4186

### Changes
`drupal/jwt` module introduced administrative permission since `1.0-beta1`, which supports drupal 8.7.x, so we will update the module to this version. 
