### PR TITLE
[SW-458] Wrong error message on register form when existing username is used

### DIFF
--- a/src/Controller/AuthenticatedContentController.php
+++ b/src/Controller/AuthenticatedContentController.php
@@ -219,7 +219,7 @@ class AuthenticatedContentController extends ControllerBase {
     $violationHints = $this->validateUser($u);
     if (!empty($violationHints)) {
       return new JsonResponse([
-        'message' => $this->t('Invalid fields:') . ' ' . implode('<br>', $violationHints),
+        'message' => $this->t('An error occurred and we’re unable to create your account. If you already have an account, please use the reset password feature to update your password.'),
       ],
         400);
     }


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SW-458

### Issue
it is a security concern
> If we add that message stating that the email already exists a hacker can create a bot to cycle through email addresses. Whenever they get that message, they register a success message. This gives them a list of valid usernames for the site. That’s half of what they need to break in to the site with a brute force attack. The message could potentially change to always say:
“An error occurred and we’re unable to create your account. If you already have an account, please use the reset password feature to update your password.”
The important part is that the error message never changes.

### Change
Just changed the violation hints message

### Thoughts 
seems like it needs FE change, as I cannot change the red message
> we are experiencing a server error.....

![image](https://user-images.githubusercontent.com/8788145/95292069-826d3100-08bc-11eb-885d-30b19a97ec01.png)

