### PR TITLE
Included a settings form to enable/disable the tide json api.

### DIFF
--- a/config/install/tide_authenticated_content.allowed_routes.yml
+++ b/config/install/tide_authenticated_content.allowed_routes.yml
@@ -1,4 +1,4 @@
-route_settings:
+allowed_routes:
   'login': 1
   'logout': 1
   'register': 1

--- a/config/install/tide_authenticated_content.route_settings.yml
+++ b/config/install/tide_authenticated_content.route_settings.yml
@@ -1,0 +1,7 @@
+route_settings:
+  'login': 1
+  'logout': 1
+  'register': 1
+  'update': 1
+  'request_reset': 1
+  'reset': 1

--- a/src/Controller/AuthenticatedContentController.php
+++ b/src/Controller/AuthenticatedContentController.php
@@ -19,7 +19,7 @@ use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Component\Utility\Html;
 
 /**
- * Class AuthenticatedContentController.
+ * Class Authenticated Content Controller.
  *
  * @package Drupal\tide_authenticated_content\Controller
  */
@@ -99,7 +99,7 @@ class AuthenticatedContentController extends ControllerBase {
   public function loginAction(
     Request $request
   ) {
-    // TODO: implement flood control.
+    // @todo implement flood control.
     $auth = UserAuthenticationController::create($this->container);
     try {
       $resp = $auth->login($request);
@@ -117,7 +117,7 @@ class AuthenticatedContentController extends ControllerBase {
       $body = json_decode($resp->getContent(),
         TRUE);
       $jwt = JwtAuthIssuerController::create($this->container);
-      // @var \Symfony\Component\HttpFoundation\Response $tokenResp
+      /** @var \Symfony\Component\HttpFoundation\Response $tokenResp */
       $tokenResp = $jwt->tokenResponse();
       if ($tokenResp->getStatusCode() == 200) {
         $token = json_decode($tokenResp->getContent(),
@@ -381,7 +381,7 @@ class AuthenticatedContentController extends ControllerBase {
     $message = $this->t('If your account is registered in our system a forgot password email has been sent to your email address.');
     $data = json_decode($request->getContent(),
       TRUE);
-    // @var \Drupal\user\Entity\User[] $users
+    /** @var \Drupal\user\Entity\User[] $users */
     $users = [];
     if (isset($data['name'])) {
       $name = $data['name'];
@@ -439,7 +439,7 @@ class AuthenticatedContentController extends ControllerBase {
         }
         $rehash = user_pass_rehash($user,
           $time);
-        // TODO: Replace hard-coded link expiry.
+        // @todo Replace hard-coded link expiry.
         // Expire in 24 hours.
         if (REQUEST_TIME - $time > 3600 * 24) {
           return new JsonResponse(['message' => $this->t('Link Expired.')],

--- a/src/Routing/AuthenticatedContentRouteSubscriber.php
+++ b/src/Routing/AuthenticatedContentRouteSubscriber.php
@@ -53,8 +53,8 @@ class AuthenticatedContentRouteSubscriber extends RouteSubscriberBase {
         $route->setRequirement('_custom_access', 'tide_authenticated_content.access_jsonapi_checker::access');
       }
     }
-    $route_config = \Drupal::config('tide_authenticated_content.route_settings');
-    $route_settings = $route_config->get("route_settings");
+    $route_config = $this->configFactory->get('tide_authenticated_content.allowed_routes');
+    $allowed_routes = $route_config->get('allowed_routes');
     $route_list = [
       'login' => 'tide_authenticated_content.user.login',
       'logout' => 'tide_authenticated_content.user.logout',
@@ -65,7 +65,7 @@ class AuthenticatedContentRouteSubscriber extends RouteSubscriberBase {
     ];
     foreach ($route_list as $key => $route_name) {
       if ($route = $collection->get($route_name)) {
-        if (!$route_settings[$key]) {
+        if (empty($allowed_routes[$key])) {
           $route->setRequirement('_access', 'FALSE');
         }
       }

--- a/src/Routing/AuthenticatedContentRouteSubscriber.php
+++ b/src/Routing/AuthenticatedContentRouteSubscriber.php
@@ -53,6 +53,23 @@ class AuthenticatedContentRouteSubscriber extends RouteSubscriberBase {
         $route->setRequirement('_custom_access', 'tide_authenticated_content.access_jsonapi_checker::access');
       }
     }
+    $route_config = \Drupal::config('tide_authenticated_content.route_settings');
+    $route_settings = $route_config->get("route_settings");
+    $route_list = [
+      'login' => 'tide_authenticated_content.user.login',
+      'logout' => 'tide_authenticated_content.user.logout',
+      'register' => 'tide_authenticated_content.user.register',
+      'update' => 'tide_authenticated_content.user.update',
+      'request_reset' => 'tide_authenticated_content.user.request_reset',
+      'reset' => 'tide_authenticated_content.user.reset',
+    ];
+    foreach ($route_list as $key => $route_name) {
+      if ($route = $collection->get($route_name)) {
+        if (!$route_settings[$key]) {
+          $route->setRequirement('_access', 'FALSE');
+        }
+      }
+    }
   }
 
 }

--- a/tests/behat/features/authenticated_content.feature
+++ b/tests/behat/features/authenticated_content.feature
@@ -56,4 +56,3 @@ Feature: Authenticated Content
     Then I should get a "401" HTTP response
     And I should see an "input#username" element
     And save screenshot
-

--- a/tide_authenticated_content.install
+++ b/tide_authenticated_content.install
@@ -72,9 +72,9 @@ function tide_authenticated_content_uninstall() {
     \Drupal::entityTypeManager()->getStorage('paragraph')->delete($paragraphs);
   }
   if ($paragraph_type_entity = ParagraphsType::load('user_authentication_block')) {
-  \Drupal::entityTypeManager()
-    ->getStorage('paragraphs_type')
-    ->delete([$paragraph_type_entity]);
+    \Drupal::entityTypeManager()
+      ->getStorage('paragraphs_type')
+      ->delete([$paragraph_type_entity]);
   }
   $node_types = NodeType::loadMultiple();
   if ($node_types) {

--- a/tide_authenticated_content.install
+++ b/tide_authenticated_content.install
@@ -134,10 +134,10 @@ function tide_authenticated_content_update_8004() {
 }
 
 /**
- * Update tide_authenticated_content configurations in database.
+ * Import yaml config of `tide_authenticated_content.allowed_routes`.
  */
 function tide_authenticated_content_update_8005() {
-  module_load_include('inc', 'tide_core', 'includes/helpers');
-  $config_location = [drupal_get_path('module', 'tide_authenticated_content') . '/config/install'];
-  _tide_import_single_config('tide_authenticated_content.allowed_routes', $config_location, TRUE);
+  /** @var \Drupal\Core\Config\ConfigInstallerInterface $configInstaller */
+  $configInstaller = \Drupal::service('config.installer');
+  $configInstaller->installDefaultConfig('module', 'tide_authenticated_content');
 }

--- a/tide_authenticated_content.install
+++ b/tide_authenticated_content.install
@@ -137,7 +137,16 @@ function tide_authenticated_content_update_8004() {
  * Import yaml config of `tide_authenticated_content.allowed_routes`.
  */
 function tide_authenticated_content_update_8005() {
-  /** @var \Drupal\Core\Config\ConfigInstallerInterface $configInstaller */
-  $configInstaller = \Drupal::service('config.installer');
-  $configInstaller->installDefaultConfig('module', 'tide_authenticated_content');
+  $data = [
+    'allowed_routes' => [
+      'login' => 1,
+      'logout' => 1,
+      'register' => 1,
+      'update' => 1,
+      'request_reset' => 1,
+      'reset' => 1,
+    ],
+  ];
+  $config = \Drupal::configFactory()->getEditable('tide_authenticated_content.allowed_routes');
+  $config->setData($data)->save();
 }

--- a/tide_authenticated_content.install
+++ b/tide_authenticated_content.install
@@ -139,5 +139,5 @@ function tide_authenticated_content_update_8004() {
 function tide_authenticated_content_update_8005() {
   module_load_include('inc', 'tide_core', 'includes/helpers');
   $config_location = [drupal_get_path('module', 'tide_authenticated_content') . '/config/install'];
-  _tide_import_single_config('tide_authenticated_content.route_settings', $config_location, TRUE);
+  _tide_import_single_config('tide_authenticated_content.allowed_routes', $config_location, TRUE);
 }

--- a/tide_authenticated_content.install
+++ b/tide_authenticated_content.install
@@ -72,9 +72,9 @@ function tide_authenticated_content_uninstall() {
     \Drupal::entityTypeManager()->getStorage('paragraph')->delete($paragraphs);
   }
   if ($paragraph_type_entity = ParagraphsType::load('user_authentication_block')) {
-    \Drupal::entityTypeManager()
-      ->getStorage('paragraphs_type')
-      ->delete([$paragraph_type_entity]);
+  \Drupal::entityTypeManager()
+    ->getStorage('paragraphs_type')
+    ->delete([$paragraph_type_entity]);
   }
   $node_types = NodeType::loadMultiple();
   if ($node_types) {
@@ -131,4 +131,13 @@ function tide_authenticated_content_update_8004() {
       _tide_set_paragraph_type_icon($paragraph_type, $icon_filename);
     }
   }
+}
+
+/**
+ * Update tide_authenticated_content configurations in database.
+ */
+function tide_authenticated_content_update_8005() {
+  module_load_include('inc', 'tide_core', 'includes/helpers');
+  $config_location = [drupal_get_path('module', 'tide_authenticated_content') . '/config/install'];
+  _tide_import_single_config('tide_authenticated_content.route_settings', $config_location, TRUE);
 }

--- a/tide_authenticated_content.module
+++ b/tide_authenticated_content.module
@@ -244,13 +244,13 @@ function _tide_authenticated_content_user_role_validation($form, FormStateInterf
 function tide_authenticated_content_form_jsonapi_settings_alter(&$form, FormStateInterface $form_state, $form_id) {
   $route_config = \Drupal::config('tide_authenticated_content.route_settings');
   $route_settings = $route_config->get("route_settings");
-  $form['tide_authenticated_content'] = array(
+  $form['tide_authenticated_content'] = [
     '#type' => 'fieldset',
     '#title' => t('Tide authenticated content'),
     '#description' => t('Enable or disable the json routes.'),
     '#collapsible' => TRUE,
     '#collapsed' => FALSE,
-  );
+  ];
   $route_list = [
     'login' => 'Login',
     'logout' => 'Logout',
@@ -260,19 +260,19 @@ function tide_authenticated_content_form_jsonapi_settings_alter(&$form, FormStat
     'reset' => 'Reset Password',
   ];
   foreach ($route_list as $key => $route_name) {
-    $form['tide_authenticated_content'][$key] = array(
+    $form['tide_authenticated_content'][$key] = [
       '#type' => 'checkbox',
       '#title' => $route_name,
       '#default_value' => $route_settings[$key],
-    );
+    ];
   }
   $form['actions']['submit']['#submit'][] = 'tide_authenticated_content_form_jsonapi_settings_submit';
 }
 
 /**
- *  Custom form submit to store additional information.
+ * Custom form submit to store additional information.
  */
-function tide_authenticated_content_form_jsonapi_settings_submit(array $form, FormStateInterface $form_state){
+function tide_authenticated_content_form_jsonapi_settings_submit(array $form, FormStateInterface $form_state) {
   $route_config = \Drupal::getContainer()->get('config.factory')->getEditable('tide_authenticated_content.route_settings');
   $route_settings = [];
   $route_list = [

--- a/tide_authenticated_content.module
+++ b/tide_authenticated_content.module
@@ -242,28 +242,28 @@ function _tide_authenticated_content_user_role_validation($form, FormStateInterf
  * Implements hook_form_FORM_ID_alter().
  */
 function tide_authenticated_content_form_jsonapi_settings_alter(&$form, FormStateInterface $form_state, $form_id) {
-  $route_config = \Drupal::config('tide_authenticated_content.route_settings');
-  $route_settings = $route_config->get("route_settings");
+  $route_config = \Drupal::config('tide_authenticated_content.allowed_routes');
+  $allowed_routes = $route_config->get('allowed_routes');
   $form['tide_authenticated_content'] = [
     '#type' => 'fieldset',
-    '#title' => t('Tide authenticated content'),
-    '#description' => t('Enable or disable the json routes.'),
+    '#title' => t('Allowed Tide Authenticated Content routes'),
+    '#description' => t('Enable or disable the routes to be available via JSON:API.'),
     '#collapsible' => TRUE,
     '#collapsed' => FALSE,
   ];
   $route_list = [
-    'login' => 'Login',
-    'logout' => 'Logout',
-    'register' => 'Register',
-    'update' => 'Update',
-    'request_reset' => 'Request Reset',
-    'reset' => 'Reset Password',
+    'login' => t('Login'),
+    'logout' => t('Logout'),
+    'register' => t('Register'),
+    'update' => t('Update'),
+    'request_reset' => t('Request Reset'),
+    'reset' => t('Reset Password'),
   ];
   foreach ($route_list as $key => $route_name) {
     $form['tide_authenticated_content'][$key] = [
       '#type' => 'checkbox',
       '#title' => $route_name,
-      '#default_value' => $route_settings[$key],
+      '#default_value' => $allowed_routes[$key],
     ];
   }
   $form['actions']['submit']['#submit'][] = 'tide_authenticated_content_form_jsonapi_settings_submit';
@@ -273,8 +273,8 @@ function tide_authenticated_content_form_jsonapi_settings_alter(&$form, FormStat
  * Custom form submit to store additional information.
  */
 function tide_authenticated_content_form_jsonapi_settings_submit(array $form, FormStateInterface $form_state) {
-  $route_config = \Drupal::getContainer()->get('config.factory')->getEditable('tide_authenticated_content.route_settings');
-  $route_settings = [];
+  $route_config = \Drupal::getContainer()->get('config.factory')->getEditable('tide_authenticated_content.allowed_routes');
+  $allowed_routes = [];
   $route_list = [
     'login',
     'logout',
@@ -284,7 +284,7 @@ function tide_authenticated_content_form_jsonapi_settings_submit(array $form, Fo
     'reset',
   ];
   foreach ($route_list as $route_name) {
-    $route_settings[$route_name] = $form_state->getValue($route_name);
+    $allowed_routes[$route_name] = $form_state->getValue($route_name);
   }
-  $route_config->set('route_settings', $route_settings)->save();
+  $route_config->set('allowed_routes', $allowed_routes)->save();
 }

--- a/tide_authenticated_content.module
+++ b/tide_authenticated_content.module
@@ -263,7 +263,7 @@ function tide_authenticated_content_form_jsonapi_settings_alter(&$form, FormStat
     $form['tide_authenticated_content'][$key] = [
       '#type' => 'checkbox',
       '#title' => $route_name,
-      '#default_value' => $allowed_routes[$key],
+      '#default_value' => $allowed_routes[$key] ?? FALSE,
     ];
   }
   $form['actions']['submit']['#submit'][] = 'tide_authenticated_content_form_jsonapi_settings_submit';
@@ -275,6 +275,7 @@ function tide_authenticated_content_form_jsonapi_settings_alter(&$form, FormStat
 function tide_authenticated_content_form_jsonapi_settings_submit(array $form, FormStateInterface $form_state) {
   $route_config = \Drupal::getContainer()->get('config.factory')->getEditable('tide_authenticated_content.allowed_routes');
   $allowed_routes = [];
+  $unset_values = [];
   $route_list = [
     'login',
     'logout',
@@ -285,6 +286,10 @@ function tide_authenticated_content_form_jsonapi_settings_submit(array $form, Fo
   ];
   foreach ($route_list as $route_name) {
     $allowed_routes[$route_name] = $form_state->getValue($route_name);
+    $unset_values[] = $route_name;
   }
   $route_config->set('allowed_routes', $allowed_routes)->save();
+  if (!empty($unset_values)) {
+    $form_state->unsetValue($unset_values);
+  }
 }

--- a/tide_authenticated_content.module
+++ b/tide_authenticated_content.module
@@ -237,3 +237,54 @@ function _tide_authenticated_content_user_role_validation($form, FormStateInterf
     }
   }
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function tide_authenticated_content_form_jsonapi_settings_alter(&$form, FormStateInterface $form_state, $form_id) {
+  $route_config = \Drupal::config('tide_authenticated_content.route_settings');
+  $route_settings = $route_config->get("route_settings");
+  $form['tide_authenticated_content'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Tide authenticated content'),
+    '#description' => t('Enable or disable the json routes.'),
+    '#collapsible' => TRUE,
+    '#collapsed' => FALSE,
+  );
+  $route_list = [
+    'login' => 'Login',
+    'logout' => 'Logout',
+    'register' => 'Register',
+    'update' => 'Update',
+    'request_reset' => 'Request Reset',
+    'reset' => 'Reset Password',
+  ];
+  foreach ($route_list as $key => $route_name) {
+    $form['tide_authenticated_content'][$key] = array(
+      '#type' => 'checkbox',
+      '#title' => $route_name,
+      '#default_value' => $route_settings[$key],
+    );
+  }
+  $form['actions']['submit']['#submit'][] = 'tide_authenticated_content_form_jsonapi_settings_submit';
+}
+
+/**
+ *  Custom form submit to store additional information.
+ */
+function tide_authenticated_content_form_jsonapi_settings_submit(array $form, FormStateInterface $form_state){
+  $route_config = \Drupal::getContainer()->get('config.factory')->getEditable('tide_authenticated_content.route_settings');
+  $route_settings = [];
+  $route_list = [
+    'login',
+    'logout',
+    'register',
+    'update',
+    'request_reset',
+    'reset',
+  ];
+  foreach ($route_list as $route_name) {
+    $route_settings[$route_name] = $form_state->getValue($route_name);
+  }
+  $route_config->set('route_settings', $route_settings)->save();
+}

--- a/tide_authenticated_content.routing.yml
+++ b/tide_authenticated_content.routing.yml
@@ -25,6 +25,7 @@ tide_authenticated_content.user.register:
   methods: [POST]
   requirements:
     _permission: 'access content'
+    _access_user_register: 'TRUE'
 
 tide_authenticated_content.user.update:
   path: '/api/v1/user/update'


### PR DESCRIPTION
On-behalf-of: @salsadigitalauorg joshua.fernandes@salsadigital.com.au

Included  a switch to toggle the individual routes in JSON:API settings /admin/config/services/jsonapi.
Included Drupal settings and permissions for routes.

![Screenshot 2021-09-13 at 9 05 27 AM](https://user-images.githubusercontent.com/83997348/133020182-f9ec647a-8aa4-484c-901d-c7f1031529f2.png)
