### PR TITLE
Replaced a deprecated service

### DIFF
--- a/src/Controller/AuthenticatedContentController.php
+++ b/src/Controller/AuthenticatedContentController.php
@@ -80,7 +80,7 @@ class AuthenticatedContentController extends ControllerBase {
     ContainerInterface $container
   ) {
     return new static($container,
-      $container->get('entity.manager')
+      $container->get('entity_type.manager')
         ->getStorage('user'),
       $container->get('module_handler'));
   }


### PR DESCRIPTION
### Issue
`entity.manager` service has been replaced by `entity_type.manager` in Drupal 9.