### PR TITLE
Fixes jwt auth bug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "drupal-module",
     "license": "GPL-2.0-or-later",
     "require": {
-        "dpc-sdp/tide_core": "^3.0.0",
+        "dpc-sdp/tide_core": "^3.0.1",
         "dpc-sdp/tide_event": "^3.0.0",
         "dpc-sdp/tide_landing_page": "^3.0.0",
         "dpc-sdp/tide_media": "^3.0.0",

--- a/src/Auth/AuthProvider.php
+++ b/src/Auth/AuthProvider.php
@@ -2,7 +2,11 @@
 
 namespace Drupal\tide_authenticated_content\Auth;
 
+use Drupal\jwt\Authentication\Event\JwtAuthEvents;
+use Drupal\jwt\Authentication\Event\JwtAuthValidateEvent;
+use Drupal\jwt\Authentication\Event\JwtAuthValidEvent;
 use Drupal\jwt\Authentication\Provider\JwtAuth;
+use Drupal\jwt\Transcoder\JwtDecodeException;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -39,6 +43,37 @@ class AuthProvider extends JwtAuth {
     }
 
     return $matches[1];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function authenticate(Request $request) {
+    $raw_jwt = self::getJwtFromRequest($request);
+
+    // Decode JWT and validate signature.
+    try {
+      $jwt = $this->transcoder->decode($raw_jwt);
+    } catch (JwtDecodeException $e) {
+      return NULL;
+    }
+
+    $validate = new JwtAuthValidateEvent($jwt);
+    // Signature is validated, but allow modules to do additional validation.
+    $this->eventDispatcher->dispatch(JwtAuthEvents::VALIDATE, $validate);
+    if (!$validate->isValid()) {
+      return NULL;
+    }
+
+    $valid = new JwtAuthValidEvent($jwt);
+    $this->eventDispatcher->dispatch(JwtAuthEvents::VALID, $valid);
+    $user = $valid->getUser();
+
+    if (!$user) {
+      return NULL;
+    }
+
+    return $user;
   }
 
 }

--- a/src/Auth/AuthProvider.php
+++ b/src/Auth/AuthProvider.php
@@ -54,7 +54,8 @@ class AuthProvider extends JwtAuth {
     // Decode JWT and validate signature.
     try {
       $jwt = $this->transcoder->decode($raw_jwt);
-    } catch (JwtDecodeException $e) {
+    }
+    catch (JwtDecodeException $e) {
       return NULL;
     }
 


### PR DESCRIPTION
### Motivation
1. jwt doesn't work with FE.

### Issue
1. `getJwtFromRequest`  was just a public function, but maintainers change it to `static` which result in our custom class(`AuthProvider`) still looks for its parent `getJwtFromRequest`

### Fix
just copy `authenticate` to custom implementation. 


