### PR TITLE
Updated function not to pass null.

### DIFF
--- a/src/Auth/AuthProvider.php
+++ b/src/Auth/AuthProvider.php
@@ -21,7 +21,7 @@ class AuthProvider extends JwtAuth {
    */
   public function applies(Request $request) {
     $auth = $request->headers->get('X-Authorization');
-    return preg_match('/^Bearer .+/', $auth??'');
+    return preg_match('/^Bearer .+/', $auth ?? '');
   }
 
   /**

--- a/src/Auth/AuthProvider.php
+++ b/src/Auth/AuthProvider.php
@@ -21,7 +21,7 @@ class AuthProvider extends JwtAuth {
    */
   public function applies(Request $request) {
     $auth = $request->headers->get('X-Authorization');
-    return preg_match('/^Bearer .+/', $auth);
+    return preg_match('/^Bearer .+/', $auth??'');
   }
 
   /**

--- a/src/PageCache/TideDisallowJwtAuthRequests.php
+++ b/src/PageCache/TideDisallowJwtAuthRequests.php
@@ -19,7 +19,7 @@ class TideDisallowJwtAuthRequests extends DisallowJwtAuthRequests {
    */
   public function check(Request $request) {
     $auth = $request->headers->get('X-Authorization');
-    if (preg_match('/^Bearer .+/', $auth??'')) {
+    if (preg_match('/^Bearer .+/', $auth ?? '')) {
       return self::DENY;
     }
 

--- a/src/PageCache/TideDisallowJwtAuthRequests.php
+++ b/src/PageCache/TideDisallowJwtAuthRequests.php
@@ -19,7 +19,7 @@ class TideDisallowJwtAuthRequests extends DisallowJwtAuthRequests {
    */
   public function check(Request $request) {
     $auth = $request->headers->get('X-Authorization');
-    if (preg_match('/^Bearer .+/', $auth)) {
+    if (preg_match('/^Bearer .+/', $auth??'')) {
       return self::DENY;
     }
 


### PR DESCRIPTION
### JIRA
https://digital-vic.atlassian.net/browse/SRM-688

### Issue 
`Deprecated function: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in Drupal\tide_authenticated_content\PageCache\TideDisallowJwtAuthRequests->check() (line 22 of /app/docroot/modules/contrib/tide_authenticated_content/src/PageCache/TideDisallowJwtAuthRequests.php)`

### Changes
Avoid passing null value