### PR TITLE
Fix an issue with explicitly set query access check

### DIFF
--- a/tide_authenticated_content.install
+++ b/tide_authenticated_content.install
@@ -51,7 +51,8 @@ function tide_authenticated_content_uninstall() {
   // Clean up paragraphs.
   $paragraph_query = \Drupal::entityTypeManager()
     ->getStorage('paragraph')
-    ->getQuery();
+    ->getQuery()
+    ->accessCheck(FALSE);
   $results = $paragraph_query->condition('type', 'user_authentication_block')
     ->execute();
   if ($results) {


### PR DESCRIPTION
### issue
```
In Query.php line 141:
                                                                                                                                                     
  Entity queries must explicitly set whether the query should be access checked or not. See Drupal\Core\Entity\Query\QueryInterface::accessCheck().
```