### PR TITLE
Added access check for entity query in uninstall hook.

### DIFF
--- a/tide_authenticated_content.install
+++ b/tide_authenticated_content.install
@@ -53,6 +53,7 @@ function tide_authenticated_content_uninstall() {
     ->getStorage('paragraph')
     ->getQuery();
   $results = $paragraph_query->condition('type', 'user_authentication_block')
+    ->accessCheck(FALSE)
     ->execute();
   if ($results) {
     $paragraphs = Paragraph::loadMultiple($results);


### PR DESCRIPTION
### Changes
The uninstall hook missing access check option for entity query and this causes issues to uninstall this module for a D10 project.